### PR TITLE
[FIX] fix first_run, 0 division error if X per day = 0, remove SEND_E…   …RROR_ALERTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ RUN_EVERY_X_MINUTES=30
 
 # Fefine how often per 24 hours you would like an alert if you are fully synced. 0 = No status notifications
 # 0 = No notifications
-FULLY_SYNCED_NOTIFICATIONS_PER_DAY=1000
+FULLY_SYNCED_NOTIFICATIONS_PER_DAY=2
 
 # Check if Shard 0 is Stuck
 # Time to wait between checking for Shard0 being frozen. IN SECONDS

--- a/alert.py
+++ b/alert.py
@@ -35,7 +35,6 @@ def run(times_sent: dict):
                 time_calc = (time_check - start_time).seconds
 
                 if time_calc >= (envs.RUN_EVERY_X_MINUTES * 60) or first_run:
-                    first_run = False
                     start_time = time_check
                     if envs.SHARD == 0:
                         res2 = True
@@ -98,6 +97,7 @@ def run(times_sent: dict):
                                 times_sent = alerts.happy_alert(
                                     envs.SHARD, times_sent, first_run=first_run
                                 )
+                    first_run = False
 
         except Exception as e:
             alerts.generic_error(e)
@@ -110,9 +110,15 @@ def run(times_sent: dict):
         envs.load_envs()
 
 
+def test_run(times_sent):
+    first_run = True
+    times_sent = alerts.happy_alert(envs.SHARD, times_sent, first_run=first_run)
+
+
 if __name__ == "__main__":
     alerts = Alerts(VSTATS_API, connect_to_api, **alerts_context)
     run(times_sent)
+    # test_run(times_sent)
 
     # alerts.send_alert(
     #     "TEST",

--- a/includes/config.py
+++ b/includes/config.py
@@ -23,12 +23,13 @@ envs = Envs()
 
 VSTATS_API = "https://vstats.one/api/serversync"
 FULLY_SYNCED_NOTIFICATIONS = False
+times, times_sent = [], {}
 
-FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS = 24 // envs.FULLY_SYNCED_NOTIFICATIONS_PER_DAY
-
-times, times_sent = parse_times(FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS)
-
-if FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS > 0:
+if envs.FULLY_SYNCED_NOTIFICATIONS_PER_DAY > 0:
+    FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS = (
+        24 / envs.FULLY_SYNCED_NOTIFICATIONS_PER_DAY
+    )
+    times, times_sent = parse_times(FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS)
     FULLY_SYNCED_NOTIFICATIONS = True
 
 alerts_context = dict(
@@ -36,3 +37,6 @@ alerts_context = dict(
     hostname=server_hostname,
     FULLY_SYNCED_NOTIFICATIONS=FULLY_SYNCED_NOTIFICATIONS,
 )
+
+
+# print(FULLY_SYNCED_NOTIFICATIONS_EVERY_X_HOURS)

--- a/util/send_alerts.py
+++ b/util/send_alerts.py
@@ -34,15 +34,14 @@ class Alerts(AlertsBase):
         return html
 
     def generic_error(self, e: str):
-        if envs.RECEIVE_ERROR_MSG:
-            self.send_alert(
-                f"Sync Script Error -- {self.hostname}",
-                e,
-                # f"Alert author\n\nError Message :: {e}",
-                "danger",
-                log.error,
-                f"Sending ERROR Alert..ERROR  ::  {e}",
-            )
+        self.send_alert(
+            f"Sync Script Error -- {self.hostname}",
+            e,
+            # f"Alert author\n\nError Message :: {e}",
+            "danger",
+            log.error,
+            f"Sending ERROR Alert..ERROR  ::  {e}",
+        )
 
     @check_hours_alert
     def happy_alert(

--- a/util/tools.py
+++ b/util/tools.py
@@ -53,7 +53,9 @@ def flatten(d: dict) -> None:
 
 
 def check_hours_alert(function_to_decorate):
-    def wrapper(self, shard, times_sent, _send_alert=False, first_run: bool = False):
+    def wrapper(
+        self, shard, times_sent, _send_alert: bool = False, first_run: bool = False
+    ):
         now = datetime.datetime.now()
         h = str(now.hour)
         if not first_run:


### PR DESCRIPTION
1. fix first_run - moved flag change

2. 0 division error if X per day = 0
check that  `envs.FULLY_SYNCED_NOTIFICATIONS_PER_DAY > 0` and no notifications will be sent if it is 0.  Previously if the user set it to 0, it would create a `ZERODIVISIONERROR`

3.  `envs.RECEIVE_ERROR_MSG` will suppress all errors so has been removed.
This can be handled at the API side by checking to see if it is an array and then checking the 'error' key for `JSONDecodeError` and suppressing it or shortening / Pretty printing the error.

**{'Error': JSONDecodeError(**'Expecting value: line 1 column 1 (char 0)'), 'stdout': '', 'stderr': 'Warning: Using outdated version. Redownload to upgrade to v417-bc3f026\ncommit: v1-71dd586, **error: http status code not 200, received: 503**\ncheck hmy cookbook for valid examples or try adding a --help flag\n'}